### PR TITLE
fix(pretty-tree): Fixes an error when the node.depth > number of available colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,8 +60,7 @@ var tree = function(color) {
     };
 
     var visit = function(node) {
-        var lastColorIdx = colors.length - 1;
-        if (node.label) node.label = colors[Math.min(node.depth, lastColorIdx)](node.label);
+        if (node.label) node.label = colors[Math.min(node.depth, colors.length - 1)](node.label);
         if (node.nodes) node.nodes = [].concat(node.nodes).map(visit);
         if (node.leaf)  node.nodes = [].concat(node.nodes || [], leaf(node.leaf));
         // if (node.label && (!node.nodes || !node.nodes.length)) node.nodes = [grey('(empty)')];

--- a/index.js
+++ b/index.js
@@ -60,7 +60,8 @@ var tree = function(color) {
     };
 
     var visit = function(node) {
-        if (node.label) node.label = colors[node.depth || 0](node.label);
+        var lastColorIdx = colors.length - 1;
+        if (node.label) node.label = colors[Math.min(node.depth, lastColorIdx)](node.label);
         if (node.nodes) node.nodes = [].concat(node.nodes).map(visit);
         if (node.leaf)  node.nodes = [].concat(node.nodes || [], leaf(node.leaf));
         // if (node.label && (!node.nodes || !node.nodes.length)) node.nodes = [grey('(empty)')];


### PR DESCRIPTION
I stumbled upon this when using https://github.com/bpxl-labs/react-component-hierarchy. 

If the depth of the node is greater than the number of colors available, an error is thrown.
